### PR TITLE
切り替え後の表示がコードになるように変更

### DIFF
--- a/QuickTestSwitcher/QuickTestSwitcherPackage.cs
+++ b/QuickTestSwitcher/QuickTestSwitcherPackage.cs
@@ -92,7 +92,7 @@ namespace bleistift.QuickTestSwitcher
             var switcher = new Switcher(project, doc);
             try
             {
-                switcher.TargetProjectItem.Open().Activate();
+                switcher.TargetProjectItem.Open(EnvDTE.Constants.vsViewKindCode).Activate();
             }
             catch (TargetProjectNotFound)
             {


### PR DESCRIPTION
#refs17 でデザイナファイルやリソースファイルに切り替わらないように修正していただきましたが、切り替え後にコードではなくデザイナが開いてしまうのは使いづらく感じたので EnvDTE.Constants.vsViewKindCode を指定し、開いた後の表示がコードになるように変更しました。
